### PR TITLE
Allow executing with a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,29 @@ rotp --help
 
 # Examples
 rotp --secret p4ssword                       # Generates a time-based one-time password
+rotp --file otp_accounts.json                # Generates passwords from a config file
 rotp --hmac --secret p4ssword --counter 42   # Generates a counter-based one-time password
+```
+
+The JSON config file for the accounts should be of the form:
+
+```JSON
+[
+  {
+    "secret":"JBSWY3DPEHPK3PXP",
+    "label":"Test label",
+    "period":30,
+    "digits":6,
+    "algorithm":"SHA1"
+  },
+  {
+    "secret":"wrn3pqx5uqxqvnqr",
+    "label":"Test label 2",
+    "period":40,
+    "digits":7,
+    "algorithm":"SHA256"
+  }
+]
 ```
 
 ## Contributors

--- a/lib/rotp.rb
+++ b/lib/rotp.rb
@@ -2,10 +2,12 @@ require 'cgi'
 require 'uri'
 require 'securerandom'
 require 'openssl'
+require 'json'
 require 'rotp/base32'
 require 'rotp/otp'
 require 'rotp/hotp'
 require 'rotp/totp'
+require 'rotp/file'
 
 
 module ROTP

--- a/lib/rotp/arguments.rb
+++ b/lib/rotp/arguments.rb
@@ -45,6 +45,7 @@ module ROTP
         parser.separator green('  Usage: ') + bold("#{filename} [options]")
         parser.separator ''
         parser.separator green '  Examples:   '
+        parser.separator '    ' + bold("#{filename} --file otp_accounts.json") + '                # Generates passwords from a config file'
         parser.separator '    ' + bold("#{filename} --secret p4ssword") + '                       # Generates a time-based one-time password'
         parser.separator '    ' + bold("#{filename} --hmac --secret p4ssword --counter 42") + '   # Generates a counter-based one-time password'
         parser.separator ''
@@ -52,6 +53,11 @@ module ROTP
 
         parser.on('-s', '--secret [SECRET]', 'The shared secret') do |secret|
           options!.secret = secret
+        end
+
+        parser.on('-f', '--file [FILE]', 'Passwords for accounts in a JSON file') do |file|
+          options!.file = file
+          options!.mode = :file
         end
 
         parser.on('-c', '--counter [COUNTER]', 'The counter for counter-based hmac OTP') do |counter|

--- a/lib/rotp/cli.rb
+++ b/lib/rotp/cli.rb
@@ -34,7 +34,8 @@ module ROTP
         ROTP::TOTP.new(options.secret).now
       elsif options.mode == :hmac
         ROTP::HOTP.new(options.secret).at options.counter
-
+      elsif options.mode == :file
+        ROTP::FILE.new(options.file).codes
       else
         fail NotImplementedError
       end

--- a/lib/rotp/file.rb
+++ b/lib/rotp/file.rb
@@ -1,0 +1,29 @@
+module ROTP
+  class FILE
+    def initialize file
+      file = File.file?(file) ? File.read(file) : ''
+
+      begin
+        @accounts = JSON.parse(file)
+      rescue JSON::ParserError
+        @accounts = {}
+      end
+    end
+
+    def codes
+      output = ''
+      @accounts.each do |account|
+        account_settings = {
+          interval: account['period'],
+          digits: account['digits'],
+          digest: account['algorithm']
+        }
+        auth_code = ROTP::TOTP.new(account['secret'], account_settings).now
+
+        output += "#{account['label']}: #{auth_code}\n"
+      end
+
+      output
+    end
+  end
+end

--- a/spec/lib/rotp/file_spec.rb
+++ b/spec/lib/rotp/file_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe ROTP::FILE do
     it 'returns the correct code' do
       file_content = [
         {
-          "secret":"JBSWY3DPEHPK3PXP",
-          "label":"Test label",
-          "period":30,
-          "digits":6,
-          "algorithm":"SHA1"
+          "secret" => "JBSWY3DPEHPK3PXP",
+          "label" => "Test label",
+          "period" => 30,
+          "digits" => 6,
+          "algorithm" => "SHA1"
         },
         {
-          "secret":"wrn3pqx5uqxqvnqr",
-          "label":"Test label 2",
-          "period":30,
-          "digits":6,
-          "algorithm":"SHA1"
+          "secret" => "wrn3pqx5uqxqvnqr",
+          "label" => "Test label 2",
+          "period" => 30,
+          "digits" => 6,
+          "algorithm" => "SHA1"
         }
       ].to_json
 
@@ -37,11 +37,11 @@ RSpec.describe ROTP::FILE do
       it 'returns the correct code' do
         file_content = [
           {
-            "secret":"JBSWY3DPEHPK3PXP",
-            "label":"Test label",
-            "period":40,
-            "digits":7,
-            "algorithm":"SHA256"
+            "secret" => "JBSWY3DPEHPK3PXP",
+            "label" => "Test label",
+            "period" => 40,
+            "digits" => 7,
+            "algorithm" => "SHA256"
           }
         ].to_json
 

--- a/spec/lib/rotp/file_spec.rb
+++ b/spec/lib/rotp/file_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'rotp/file'
+
+RSpec.describe ROTP::FILE do
+  let(:now) { Time.utc 2012,1,1 }
+
+  before do
+    Timecop.freeze now
+  end
+
+  context 'Given a file' do
+    it 'returns the correct code' do
+      file_content = [
+        {
+          "secret":"JBSWY3DPEHPK3PXP",
+          "label":"Test label",
+          "period":30,
+          "digits":6,
+          "algorithm":"SHA1"
+        },
+        {
+          "secret":"wrn3pqx5uqxqvnqr",
+          "label":"Test label 2",
+          "period":30,
+          "digits":6,
+          "algorithm":"SHA1"
+        }
+      ].to_json
+
+      allow(File).to receive(:read).and_return(file_content)
+      allow(File).to receive(:file?).and_return(true)
+
+      expect(ROTP::FILE.new('file_name').codes).to eq "Test label: 068212\nTest label 2: 408799\n"
+    end
+
+    context 'with different settings' do
+      it 'returns the correct code' do
+        file_content = [
+          {
+            "secret":"JBSWY3DPEHPK3PXP",
+            "label":"Test label",
+            "period":40,
+            "digits":7,
+            "algorithm":"SHA256"
+          }
+        ].to_json
+
+        allow(File).to receive(:read).and_return(file_content)
+        allow(File).to receive(:file?).and_return(true)
+
+        expect(ROTP::FILE.new('file_name').codes).to eq "Test label: 1200080\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
I would like the ability to run the rotp executable by passing in a config file like this:

```bash
rotp --file otp_accounts.json
```
Where the file looks like this:

```JSON
[
  {
    "secret":"JBSWY3DPEHPK3PXP",
    "label":"Test label",
    "period":30,
    "digits":6,
    "algorithm":"SHA1"
  },
  {
    "secret":"wrn3pqx5uqxqvnqr",
    "label":"Test label 2",
    "period":40,
    "digits":7,
    "algorithm":"SHA256"
  }
]
```
(The above config is the same as the export from the Android app andOTP)

And I would expect an output like this:

```
Test label: 068212
Test label 2: 408799
```

I implemented this feature and wrote the corresponding tests.

Sorry if I'm not following any style standards correctly. If you notice anything that should be different just ask and I will change it.
